### PR TITLE
設定ウィンドウにおける色付きユーザーIDの削除を、ランキング表示時に反映するようにした

### DIFF
--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -973,14 +973,9 @@ Namespace ViewModel
                 Next
             Next
 
-            Dim ids = _HighlightUsers.Split(New Char() {","c}, StringSplitOptions.None)
+            Dim ids = _HighlightUsers.Split(New Char() {","c}, StringSplitOptions.None).Select(Function(id) id.Trim()).ToArray()
             For Each m In Member.Keys
-                For Each id In ids
-                    If m = id.Trim Then
-                        Member(m).Highlighted = True
-                        Exit For
-                    End If
-                Next
+                Member(m).Highlighted = ids.Contains(m)
             Next
 
             For Each m In Member.Values


### PR DESCRIPTION
この問題は、しろさん <https://twitter.com/siroro> に報告していただきました。