### PR TITLE
問題が起こった場合の動作を変更

### DIFF
--- a/NamaTyping/ScreenWindow.xaml
+++ b/NamaTyping/ScreenWindow.xaml
@@ -238,9 +238,10 @@
         </ToolBarPanel>
 
         <StatusBar Grid.Row="4">
-            <StatusBarItem x:Name="statusBarItem">
+            <StatusBarItem x:Name="statusBarItem" MaxWidth="{Binding ElementName=ScreenWindowsFormsHost, Path=Width}">
                 <TextBox IsReadOnly="True" x:Name="StatusTextBox" Text="{Binding StatusMessage}"
-						 BorderThickness="0" Background="Transparent" VerticalAlignment="Center">
+						 BorderThickness="0" Background="Transparent" VerticalAlignment="Center"
+                         MaxLines="1" ToolTip="{Binding RelativeSource={RelativeSource Self}, Path=Text}">
                     <i:Interaction.Triggers>
                         <i:EventTrigger EventName="TextChanged">
                             <ei:ControlStoryboardAction Storyboard="{StaticResource FadeStoryboard}"/>

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -793,24 +793,12 @@ Namespace ViewModel
 
 
                 Dim l = New Lyrics
-                Try
-                    l.Load(dialog.FileName)
 
-                    If Not l.Exists Then
-                        If l.ReplacementWordsFileName Is Nothing Then
-                            StatusMessage = "置換ファイル(.rep.txt, .repl.txt)がありません"
-                        ElseIf l.LyricsFileName Is Nothing Then
-                            StatusMessage = "歌詞ファイル(.lrc)がありません"
-                        ElseIf l.VideoFileName Is Nothing OrElse Lyrics.SoundFileName Is Nothing Then
-                            StatusMessage = "動画またはサウンドファイルがありません"
-                        End If
-                        Exit Sub
-                    End If
-
-                Catch ex As Exception
-                    StatusMessage = "ファイル読み込み中にエラーが発生しました"
+                Dim errorMessage As String = Nothing
+                If Not l.TryLoad(dialog.FileName, errorMessage) Then
+                    StatusMessage = errorMessage
                     Exit Sub
-                End Try
+                End If
 
                 Lyrics = l
 


### PR DESCRIPTION
- 「開く」からのXMLファイル読み込みに失敗したとき、ステータスバーへ具体的なエラーメッセージを表示するようになりました。
- アプリケーションに問題が起きた場合、エラーの詳細を表示し、すぐに終了するようになりました。