### PR TITLE
動画、音声ファイルの対応拡張子 (XMLの場合はtype属性値) を追加

### DIFF
--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -6,6 +6,29 @@ Namespace Model
 
     Public Class Lyrics
 
+        ''' <summary>
+        ''' 動画ファイルの拡張子。音声ファイルでも使う拡張子のうち、音声ファイルである場合が多い拡張子は含まない。
+        ''' </summary>
+        ''' <returns></returns>
+        Private ReadOnly Property VideoFileExtensions As String() = {
+            ".3g2", ".3gp", ".3gp2", ".asf", ".avi", ".flv", ".ivf", ".m4v", ".mov", ".mp4", ".mp4v", ".mpeg", ".mpg", ".ogv", ".ogx", ".webm", ".wm", ".wmv"
+        }
+
+        ''' <summary>
+        ''' 音声ファイルの拡張子。動画ファイルでも使う拡張子のうち、動画ファイルである場合が多い拡張子は含まない。
+        ''' </summary>
+        ''' <returns></returns>
+        Private ReadOnly Property AudioFileExtensions As String() = {
+            ".aac", ".aif", ".aifc", ".aiff", ".au", ".m4a", ".mid", ".midi", ".mp2", ".mp3", ".mpa", ".oga", ".ogg", ".rmi", ".snd", ".spx", ".wav", ".wma"
+        }
+
+        ''' <summary>
+        ''' 画像ファイルの拡張子。
+        ''' </summary>
+        ''' <returns></returns>
+        Private ReadOnly Property ImageFileExtensions As String() = {
+            ".jpg", ".jpeg", ".png", ".bmp"
+        }
 
         Private _ReplacementWords As New Dictionary(Of String, String)
         Public ReadOnly Property ReplacementWords() As IDictionary(Of String, String)
@@ -159,7 +182,7 @@ Namespace Model
                     If link.@rel = "alternate" Then
                         LyricsFileName = f
 
-                    ElseIf link.@rel = "enclosure" Then
+                    ElseIf link.@rel = "enclosure" AndAlso link.@type IsNot Nothing Then
 
                         Select Case link.@type
                             Case "text/plain"
@@ -170,14 +193,15 @@ Namespace Model
                                     NgWordsFileName = f
                                 End If
 
-                            Case "video/x-ms-wmv"
-                                VideoFileName = f
-
                             Case "image/png", "iamge/png", "image/jpeg", "image/bmp"
                                 ImageFileName = f
 
-                            Case "audio/mpeg"
-                                SoundFileName = f
+                            Case Else
+                                If link.@type.StartsWith("video/") Then
+                                    VideoFileName = f
+                                ElseIf link.@type.StartsWith("audio/") Then
+                                    SoundFileName = f
+                                End If
 
                         End Select
                     End If
@@ -219,29 +243,16 @@ Namespace Model
                 LyricsFileName = lrcFile
             End If
 
-            Dim wmvFile = System.IO.Path.Combine(path, fileNameWithoutExtenstion & ".wmv")
-            If System.IO.File.Exists(wmvFile) Then
-                VideoFileName = wmvFile
-            Else
-                Dim mp3File = System.IO.Path.Combine(path, fileNameWithoutExtenstion & ".mp3")
-                If System.IO.File.Exists(mp3File) Then
-                    SoundFileName = mp3File
+            For Each fileInfo In New System.IO.DirectoryInfo(path).GetFiles(fileNameWithoutExtenstion & ".*")
+                Dim extension = fileInfo.Name.Substring(fileNameWithoutExtenstion.Length).ToLower()
+                If VideoFileExtensions.Contains(extension) Then
+                    VideoFileName = fileInfo.FullName
+                ElseIf AudioFileExtensions.Contains(extension) Then
+                    SoundFileName = fileInfo.FullName
+                ElseIf ImageFileExtensions.Contains(extension) Then
+                    ImageFileName = fileInfo.FullName
                 End If
-
-                Dim wmaFile = System.IO.Path.Combine(path, fileNameWithoutExtenstion & ".wma")
-                If System.IO.File.Exists(wmaFile) Then
-                    SoundFileName = wmaFile
-                End If
-
-                Dim supportImageExtensions = New String() {".jpg", ".jpeg", ".png", ".bmp"}
-                For Each ext In supportImageExtensions
-                    Dim imageFile = System.IO.Path.Combine(path, fileNameWithoutExtenstion & ext)
-                    If System.IO.File.Exists(imageFile) Then
-                        ImageFileName = imageFile
-                        Exit For
-                    End If
-                Next
-            End If
+            Next
 
             Encoding = System.Text.Encoding.GetEncoding("Shift_JIS")
 

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -822,7 +822,7 @@ Namespace ViewModel
 
             IsLoaded = True
 
-            ' 総時間表示のため Pause で Media を開く
+            ' 総時間表示、およびメディア形式検証のため Pause で Media を開く
             Player.Pause()
             Player.Position = TimeSpan.FromSeconds(0)
             OnPropertyChanged("MediaLength")
@@ -1123,6 +1123,14 @@ Namespace ViewModel
 
         Private Sub _Player_MediaOpened(ByVal sender As Object, ByVal e As System.Windows.RoutedEventArgs) Handles _Player.MediaOpened
             OnPropertyChanged("MediaLength")
+        End Sub
+
+        Private Sub _Player_MediaFailed(ByVal sender As Object, ByVal e As System.Windows.RoutedEventArgs) Handles _Player.MediaFailed
+            StatusMessage = String.Format(
+                "「{0}」はWindows Media Playerで再生できない{1}ファイルです。",
+                My.Computer.FileSystem.GetName(If(Lyrics.SoundFileName, Lyrics.VideoFileName)),
+                If(Lyrics.SoundFileName IsNot Nothing, "音声", "動画")
+            )
         End Sub
 
         Private Sub _Player_MediaEnded(ByVal sender As Object, ByVal e As System.Windows.RoutedEventArgs) Handles _Player.MediaEnded

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -812,12 +812,12 @@ Namespace ViewModel
             OnPropertyChanged("BackgroundImage")
             Player.Close()
 
-            If Lyrics.SoundFileName <> "" Then
-                Player.Source = New Uri(Lyrics.SoundFileName)
-
-            ElseIf Lyrics.VideoFileName <> "" Then
+            If Lyrics.VideoFileName <> "" Then
                 BackgroundImage = Nothing
                 Player.Source = New Uri(Lyrics.VideoFileName)
+            ElseIf Lyrics.SoundFileName <> "" Then
+                Player.Source = New Uri(Lyrics.SoundFileName)
+
             End If
 
             IsLoaded = True


### PR DESCRIPTION
- 読み込めるかどうかは、ファイルに含まれるデータの形式、パソコンにインストールされているコーデック、およびWindows Media Playerの設定に依存します。
	+ 同じファイル形式でも、含まれるデータの形式はまったく異なる場合があります。
- Windows Media Playerで再生できるファイルなら、**同じパソコンの** ニコ生タイピングでも読み込めます。
	+ lrcファイルを直接読み込んだ場合、拡張子によってはニコ生タイピングから認識されないことがあります。
	+ Windows Media Playerで再生しようとしたときに、`再生されたファイルは、Windows Media Player で認識されない拡張子を持っていますが、再生できることがあります。` といったダイアログが表示される拡張子のファイルはニコ生タイピングでは読み込めません。 (以前同じダイアログが表示されたとき、`今後、この拡張子の再生について確認しない` にチェックを入れた拡張子のファイルは読み込み可能)
- MP4 (H.264/AAC) であれば、基本的にどのパソコンでも再生できます。 (拡張子: `*.mp4` `*.m4a`)