### PR TITLE
歌詞、またはコメントに「ヴ」「ゔ」「ヰ」「ゐ」「ヱ」「え」が含まれているとき、上手く扱えていなかった問題を修正

### DIFF
--- a/NamaTyping/ExtensionModule.vb
+++ b/NamaTyping/ExtensionModule.vb
@@ -54,8 +54,8 @@ Module ExtensionModule
             Alphanumerics.Add(wideChars(i), harfChars(i))
         Next
 
-        Const katakana As String = "ヲァィゥェォャュョッアイウエオナニヌネノマミムメモヤユヨラリルレロワンカキクケコサシスセソタチツテトハヒフヘホガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポ"
-        Const hiragana As String = "をぁぃぅぇぉゃゅょっあいうえおなにぬねのまみむめもやゆよらりるれろわんかきくけこさしすせそたちつてとはひふへほがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽ"
+        Const katakana As String = "ヲァィゥェォャュョッアイウエオナニヌネノマミムメモヤユヨラリルレロワンカキクケコサシスセソタチツテトハヒフヘホガギグゲゴザジズゼゾダヂヅデドバビブベボパピプペポヴヰヱ"
+        Const hiragana As String = "をぁぃぅぇぉゃゅょっあいうえおなにぬねのまみむめもやゆよらりるれろわんかきくけこさしすせそたちつてとはひふへほがぎぐげござじずぜぞだぢづでどばびぶべぼぱぴぷぺぽゔゐゑ"
 
         For i = 0 To katakana.Length - 1
             KanaDictionary.Add(katakana(i), hiragana(i))


### PR DESCRIPTION
歌詞 `ヴァイオリン` に対するコメントの採点として

### 前のバージョン
- `ヴァイオリン` → `Great`
- `ヴぁいおりん` → `Good`
- `ゔぁいおりん` → `None`

### 現在のバージョン
- `ヴァイオリン` → `Great`
- `ヴぁいおりん` → `Good`
- `ゔぁいおりん` → `Good`