### PR TITLE
すべてから部屋のコメントを取得する設定を追加 (立ち見対応) ※既定で無効

### DIFF
--- a/NamaTyping/Application.xaml.vb
+++ b/NamaTyping/Application.xaml.vb
@@ -169,6 +169,7 @@ Class Application
         My.Settings.RecentLyricLineCount = ViewModel.RecentLyricLineCount
         My.Settings.Volume = ViewModel.Volume
         My.Settings.WindowSizePattern = ViewModel.WindowSizePattern
+        My.Settings.ConnectAllCommentServers = ViewModel.ConnectAllCommentServers
 
         My.Settings.WindowLeft = ScreenWindow.Left
         My.Settings.WindowTop = ScreenWindow.Top

--- a/NamaTyping/ConsoleWindow.xaml
+++ b/NamaTyping/ConsoleWindow.xaml
@@ -19,15 +19,18 @@
             <TextBlock Text="色付きユーザー ID（コンマ区切り）:" Margin="0 10 0 0" />
             <TextBox Text="{Binding Path=HighlightUsers}" />
 
-            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0 10 0 0">
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="0,10">
                 <TextBlock Text="歌詞・ランキング背景の不透明度:" VerticalAlignment="Center" />
                 <Slider Width="150" Margin="5 0 5 0" Value="{Binding BottomGridOpacity}" VerticalAlignment="Center" Maximum="1.0" Minimum="0" LargeChange="0.2" />
                 <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="{Binding BottomGridOpacity, StringFormat=0.00}" />
             </StackPanel>
 
+            <CheckBox Content="すべてから部屋のコメントを取得する" IsChecked="{Binding ConnectAllCommentServers}" />
+            <TextBlock Text="※ チャンネル生放送、および公式生放送には未対応" />
+
         </StackPanel>
 
-        <GroupBox Header="運営NGワード" Grid.Row="1" ToolTip="内蔵置換ファイルと外部から取得した置換ファイルが両方ある場合、更新日時が新しい方を読み込みます。">
+        <GroupBox Header="運営NGワード" Grid.Row="1" ToolTip="内蔵置換ファイルと外部から取得した置換ファイルが両方ある場合、更新日時が新しい方を読み込みます。" Margin="0,10,0,0">
             <StackPanel>
                 <CheckBox Content="歌詞の一致部分を強調表示" IsChecked="{Binding BlacklistCharactersHighlight}"/>
                 <Grid HorizontalAlignment="Right">

--- a/NamaTyping/My Project/Settings.Designer.vb
+++ b/NamaTyping/My Project/Settings.Designer.vb
@@ -309,6 +309,23 @@ Partial Friend NotInheritable Class MySettings
     End Property
     
     '''<summary>
+    '''すべての部屋からコメントを取得する。
+    '''</summary>
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("すべての部屋からコメントを取得する。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("False"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
+    Public Property ConnectAllCommentServers() As Boolean
+        Get
+            Return CType(Me("ConnectAllCommentServers"),Boolean)
+        End Get
+        Set
+            Me("ConnectAllCommentServers") = value
+        End Set
+    End Property
+    
+    '''<summary>
     '''ウィンドウの横位置のキャッシュ。
     '''</summary>
     <Global.System.Configuration.UserScopedSettingAttribute(),  _

--- a/NamaTyping/My Project/Settings.settings
+++ b/NamaTyping/My Project/Settings.settings
@@ -47,6 +47,9 @@
     <Setting Name="BlacklistCharactersHighlight" Description="運営NGワードの強調などを行う。" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
+    <Setting Name="ConnectAllCommentServers" Description="すべての部屋からコメントを取得する。" Roaming="true" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
     <Setting Name="WindowLeft" Description="ウィンドウの横位置のキャッシュ。" Type="System.Double" Scope="User">
       <Value Profile="(Default)">NaN</Value>
     </Setting>

--- a/NamaTyping/app.config
+++ b/NamaTyping/app.config
@@ -80,6 +80,9 @@
       <setting name="BlacklistCharactersHighlight" serializeAs="String">
         <value>True</value>
       </setting>
+      <setting name="ConnectAllCommentServers" serializeAs="String">
+        <value>False</value>
+      </setting>
       <setting name="WindowLeft" serializeAs="String">
         <value>NaN</value>
       </setting>

--- a/NicoVideo/NicoVideo.Full/LiveStreaming/ChatSource.vb
+++ b/NicoVideo/NicoVideo.Full/LiveStreaming/ChatSource.vb
@@ -6,6 +6,7 @@
         Alert = 2
         Broadcaster = 3
         [Operator] = 6
+        BSP = 7
     End Enum
 
 End Namespace


### PR DESCRIPTION
- メインウィンドウ右上の設定ボタンで開く設定ウィンドウから有効化できます。
- ユーザー生放送 (ニコニコミュニティのライブ配信) のみに対応しており、チャンネル生放送、公式生放送には未対応です。
- コミュニティレベルをもとに部屋数を予測しています。
	+ 現バージョンでは、以下の表の通りに処理しています。
		* この対応関係は正確ではない可能性があり、加えて仕様が変更される可能性もあります。そのため、境界付近のレベルのコミュニティでは、この機能を正常に利用できないかもしれません。
	+ 配信ページに接続してレベルを取得しているため、サイトのデザイン変更等で取得に失敗した場合、立ち見Aしか存在しない扱いになります。

| レベル   | 立ち見部屋 |
|----------|------------|
| 〜49     | 立ち見A    |
| 50〜69   | 立ち見A、B |
| 70〜104  | 立ち見A〜C |
| 105〜149 | 立ち見A〜D |
| 150〜189 | 立ち見A〜E |
| 190〜229 | 立ち見A〜F |
| 230〜255 | 立ち見A〜G |
| 256〜    | 立ち見A〜I |