### PR TITLE
バグの修正や内部的な改善

### DIFF
--- a/NamaTyping/CharacterReplacer.vb
+++ b/NamaTyping/CharacterReplacer.vb
@@ -1,5 +1,6 @@
 ﻿Imports System.Xml
 Imports System.Text.RegularExpressions
+Imports System.IO
 
 ''' <summary>
 ''' ニコニコ生放送の運営NGワードに関する処理を行います。
@@ -104,7 +105,7 @@ Friend NotInheritable Class CharacterReplacer
     ''' 外部から取得したNGワード置換ファイルの保存先。
     ''' </summary>
     ''' <returns></returns>
-    Private ReadOnly Property FilePath As String = My.Computer.FileSystem.CombinePath(My.Settings.ParentPath, "SubstList.xml")
+    Private ReadOnly Property FilePath As String = Path.Combine(My.Settings.ParentPath, "SubstList.xml")
 
     Friend Sub New()
         If My.Settings.BlacklistCharactersSeparator.Length = 0 OrElse Regex.IsMatch(My.Settings.BlacklistCharactersSeparator, LetterOrDigitPatternString) Then
@@ -200,7 +201,7 @@ Friend NotInheritable Class CharacterReplacer
     ''' NGワード置換ファイルを読み込みます。
     ''' </summary>
     Private Sub Load()
-        If My.Computer.FileSystem.FileExists(FilePath) Then
+        If File.Exists(FilePath) Then
             Dim doc = New XmlDocument
             Try
                 doc.Load(FilePath)

--- a/NamaTyping/Converter/NullToUnsetValueConverter.vb
+++ b/NamaTyping/Converter/NullToUnsetValueConverter.vb
@@ -1,0 +1,22 @@
+﻿Imports System.Globalization
+
+Namespace Converter
+
+    ''' <summary>
+    ''' <c>Nothing</c>を<see cref="DependencyProperty.UnsetValue"/>へ変換します。
+    ''' </summary>
+    ''' <seealso cref="ImageSourceConverter"/>
+    Public Class NullToUnsetValueConverter
+        Implements IValueConverter
+
+        Function Convert(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.Convert
+            Return If(value, DependencyProperty.UnsetValue)
+        End Function
+
+        Function ConvertBack(value As Object, targetType As Type, parameter As Object, culture As CultureInfo) As Object Implements IValueConverter.ConvertBack
+            Return Binding.DoNothing
+        End Function
+
+    End Class
+
+End Namespace

--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -147,7 +147,7 @@ Namespace Model
             Try
                 doc = XDocument.Load(file)
             Catch ex As System.Xml.XmlException
-                errorMessage = $"「{My.Computer.FileSystem.GetName(file)}」の読み込みに失敗しました: {ex.Message}"
+                errorMessage = $"「{System.IO.Path.GetFileName(file)}」の読み込みに失敗しました: {ex.Message}"
                 Return False
             End Try
             Dim path = System.IO.Path.GetDirectoryName(file)

--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -118,9 +118,13 @@ Namespace Model
                 Exit Sub
             End If
 
-            If TryLoadLyrics(LyricsFileName, Encoding) Then
-                LoadReplacementWords(ReplacementWordsFileName, ReplacementWordsFileEncoding)
-            Else
+            Dim previousReplacementWords = New Dictionary(Of String, String)(ReplacementWords)
+            LoadReplacementWords(ReplacementWordsFileName, ReplacementWordsFileEncoding)
+            If Not TryLoadLyrics(LyricsFileName, Encoding) Then
+                ReplacementWords.Clear()
+                For Each values In previousReplacementWords
+                    ReplacementWords.Add(values)
+                Next
                 MessageBox.Show(
                     $"「{System.IO.Path.GetFileName(LyricsFileName)}」にはタイムタグで始まる行がありません",
                     My.Application.Info.Title,

--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -314,26 +314,22 @@ Namespace Model
             If My.Settings.SplitBlacklistCharacters Then
                 t = CharacterReplacer.SplitWords(t)
             End If
+
             For Each l In ReadLinesWithoutBlankLines(t)
-                If Not l.StartsWith("[") Then
-                    Continue For
+                Dim m = Regex.Match(l, "^\[\d{2}:\d{2}:\d{2}\](?<karaoke>.*\[\d{2}:\d{2}:\d{2}\])?")
+                If m.Success Then
+                    rawLines.Add(l)
+
+                    ' 1行に複数タイムタグがあるか
+                    If Not WipeEnabled AndAlso m.Groups.Item("karaoke").Success Then
+                        WipeEnabled = True
+                    End If
                 End If
-                rawLines.Add(l)
             Next
 
             If rawLines.Count = 0 Then
                 Return False
             End If
-
-            ' 1行に複数タイムタグがあるか
-            For Each l In rawLines
-                Dim m = Regex.Matches(l, "\[\d{2}:\d{2}:\d{2}\]")
-                If m.Count > 1 Then
-                    WipeEnabled = True
-                    Exit For
-                End If
-            Next
-
 
             For i = 0 To rawLines.Count - 2
                 If Not rawLines(i).EndsWith("]") Then

--- a/NamaTyping/NamaTyping.vbproj
+++ b/NamaTyping/NamaTyping.vbproj
@@ -128,6 +128,7 @@
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </ApplicationDefinition>
+    <Compile Include="Converter\NullToUnsetValueConverter.vb" />
     <Compile Include="ReplacementWordsGenerator.vb" />
     <Compile Include="TextEncoding.vb" />
     <Compile Include="CharacterReplacer.vb" />

--- a/NamaTyping/NamaTyping.vbproj
+++ b/NamaTyping/NamaTyping.vbproj
@@ -103,6 +103,9 @@
       <HintPath>..\packages\System.Runtime.InteropServices.RuntimeInformation.4.3.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ValueTuple, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.3.1\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Windows.Interactivity" />
     <Reference Include="System.Xaml" />

--- a/NamaTyping/ReplacementWordsGenerator.vb
+++ b/NamaTyping/ReplacementWordsGenerator.vb
@@ -86,8 +86,8 @@ Friend NotInheritable Class ReplacementWordsGenerator
 
             For i = 2 To MaxDuplicateFileName
                 Dim fileName = $"{fileNameWithoutNumber}({i}){extension}"
+                uniquePath = Path.Combine(directoryPath, fileName)
                 If Not filenames.Contains(fileName) Then
-                    uniquePath = Path.Combine(directoryPath, fileName)
                     Return True
                 End If
             Next

--- a/NamaTyping/ReplacementWordsGenerator.vb
+++ b/NamaTyping/ReplacementWordsGenerator.vb
@@ -44,8 +44,8 @@ Friend NotInheritable Class ReplacementWordsGenerator
     ''' <param name="errorMessage">保存先のフォルダがファイルを保存できる状態でなかった場合のエラーメッセージ。</param>
     ''' <returns>保存に成功した場合に<c>True</c>を返します。</returns>
     Friend Shared Function TryGenerate(ByVal inputPath As String, Optional ByRef outputPath As String = Nothing, Optional ByRef errorMessage As String = Nothing) As Boolean
-        Dim outputDirectoryPath = My.Computer.FileSystem.GetParentPath(If(outputPath, inputPath))
-        If (My.Computer.FileSystem.GetDirectoryInfo(outputDirectoryPath).Attributes And FileAttributes.ReadOnly) > 0 Then
+        Dim outputDirectoryPath = Path.GetDirectoryName(If(outputPath, inputPath))
+        If (New DirectoryInfo(outputDirectoryPath).Attributes And FileAttributes.ReadOnly) > 0 Then
             errorMessage = "フォルダは読み取り専用です。"
             Return False
         End If
@@ -56,7 +56,7 @@ Friend NotInheritable Class ReplacementWordsGenerator
             Return False
         End If
 
-        My.Computer.FileSystem.WriteAllText(outputPath, Generate(StripTags(TextEncoding.ReadAllText(inputPath))), False)
+        File.WriteAllText(outputPath, Generate(StripTags(TextEncoding.ReadAllText(inputPath))))
         Return True
     End Function
 

--- a/NamaTyping/ScreenControl.xaml
+++ b/NamaTyping/ScreenControl.xaml
@@ -12,6 +12,7 @@
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
         <converter:TimeSpanToStringConverter x:Key="TimeSpanToStringConverter" />
         <converter:NegationBooleanToVisibilityConverter x:Key="NegationBooleanToVisibilityConverter" />
+        <converter:NullToUnsetValueConverter x:Key="NullToUnsetValueConverter" />
     </UserControl.Resources>
 
     <Grid Grid.Row="1">
@@ -77,7 +78,7 @@
     		</VisualStateGroup>
     	</VisualStateManager.VisualStateGroups>
 
-        <Image Source="{Binding BackgroundImage}" Width="640" Height="480" Stretch="Uniform"
+        <Image Source="{Binding BackgroundImage, Converter={StaticResource NullToUnsetValueConverter}}" Width="640" Height="480" Stretch="Uniform"
                HorizontalAlignment="Center" VerticalAlignment="Center"
                x:Name="MyImage" />
         <MediaElement  Width="640" Height="480" Stretch="Uniform" HorizontalAlignment="Center" VerticalAlignment="Center"

--- a/NamaTyping/ScreenWindow.xaml.vb
+++ b/NamaTyping/ScreenWindow.xaml.vb
@@ -251,7 +251,7 @@ Partial Public Class ScreenWindow
             Dim errorMessage As String = Nothing
             ViewModel.StatusMessage = If(
                 ReplacementWordsGenerator.TryGenerate(dialog.FileName, outputFilePath, errorMessage),
-                $"ファイル名「{My.Computer.FileSystem.GetName(outputFilePath)}」で保存しました。",
+                $"ファイル名「{IO.Path.GetFileName(outputFilePath)}」で保存しました。",
                 errorMessage
             )
         End If

--- a/NamaTyping/Settings.vb
+++ b/NamaTyping/Settings.vb
@@ -37,7 +37,7 @@ Partial Friend NotInheritable Class MySettings
     ''' ユーザー設定ファイル (user.config) が保存されているフォルダのパス。
     ''' </summary>
     ''' <returns></returns>
-    Friend ReadOnly Property ParentPath As String = My.Computer.FileSystem.GetParentPath(FilePath)
+    Friend ReadOnly Property ParentPath As String = Path.GetDirectoryName(FilePath)
 
     ''' <summary>
     ''' <see cref="Upgrade"/>を呼び出し済みなら真。
@@ -81,17 +81,17 @@ Partial Friend NotInheritable Class MySettings
     ''' </summary>
     ''' <param name="oldVersion">旧バージョン番号。</param>
     Private Sub CopyOldVersionFiles(ByVal oldVersion As String)
-        Dim oldParentPath = My.Computer.FileSystem.CombinePath(My.Computer.FileSystem.GetParentPath(ParentPath), oldVersion)
+        Dim oldParentPath = Path.Combine(Path.GetDirectoryName(ParentPath), oldVersion)
         If oldParentPath <> ParentPath Then
-            Dim exclusionFileName = My.Computer.FileSystem.GetName(FilePath)
+            Dim exclusionFileName = Path.GetFileName(FilePath)
             Dim oldDirectory = New DirectoryInfo(oldParentPath)
             For Each entry As FileSystemInfo In oldDirectory.EnumerateFileSystemInfos()
                 If entry.Name <> exclusionFileName Then
-                    Dim newEntryPath = My.Computer.FileSystem.CombinePath(ParentPath, My.Computer.FileSystem.GetName(entry.Name))
+                    Dim newEntryPath = Path.Combine(ParentPath, Path.GetFileName(entry.Name))
                     If (entry.Attributes And FileAttributes.Directory) = FileAttributes.Directory Then
                         My.Computer.FileSystem.CopyDirectory(entry.FullName, newEntryPath)
                     Else
-                        My.Computer.FileSystem.CopyFile(entry.FullName, newEntryPath)
+                        File.Copy(entry.FullName, newEntryPath)
                     End If
                 End If
             Next

--- a/NamaTyping/TextEncoding.vb
+++ b/NamaTyping/TextEncoding.vb
@@ -19,7 +19,7 @@ Friend NotInheritable Class TextEncoding
     ''' <returns></returns>
     Friend Shared Function ReadAllText(ByVal file As String, Optional ByRef encoding As Encoding = Nothing) As String
         If encoding Is Nothing Then
-            Dim bytes = My.Computer.FileSystem.ReadAllBytes(file)
+            Dim bytes = IO.File.ReadAllBytes(file)
             Dim detector = New CharsetDetector()
             detector.Feed(bytes, 0, bytes.Length)
             detector.DataEnd()
@@ -29,7 +29,7 @@ Friend NotInheritable Class TextEncoding
             End If
             Return encoding.GetString(bytes)
         Else
-            Return My.Computer.FileSystem.ReadAllText(file, encoding)
+            Return IO.File.ReadAllText(file, encoding)
         End If
     End Function
 

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -1225,7 +1225,7 @@ Namespace ViewModel
 
         Private Sub _Player_MediaFailed(ByVal sender As Object, ByVal e As System.Windows.ExceptionRoutedEventArgs) Handles _Player.MediaFailed
             If TypeOf e.ErrorException Is COMException Then
-                Dim fileName = My.Computer.FileSystem.GetName(If(Lyrics.SoundFileName, Lyrics.VideoFileName))
+                Dim fileName = IO.Path.GetFileName(If(Lyrics.SoundFileName, Lyrics.VideoFileName))
                 Dim type = If(Lyrics.SoundFileName IsNot Nothing, "音声", "動画")
                 Select Case e.ErrorException.HResult
                     Case MilaverrLoadfailed

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -394,7 +394,7 @@ Namespace ViewModel
 
             If (e.Comment.Source <> ChatSource.Broadcaster OrElse
                     TypeOf sender Is LiveProgramClient AndAlso LiveProgramClientAndRoomLabels.Count > 1 AndAlso
-                        Not LiveProgramClientAndRoomLabels.Find(Function(clientAndLabel) clientAndLabel.Item1 Is sender).Item2.StartsWith("立ち見")) AndAlso
+                        Not LiveProgramClientAndRoomLabels.Find(Function(clientAndLabel) clientAndLabel.client Is sender).label.StartsWith("立ち見")) AndAlso
                 e.Comment.Source <> ChatSource.General AndAlso
                 e.Comment.Source <> ChatSource.Premium Then
                 Exit Sub
@@ -858,7 +858,7 @@ Namespace ViewModel
 #Region "Connect"
         Private Connecting As Boolean
 
-        Private ReadOnly LiveProgramClientAndRoomLabels As List(Of Tuple(Of LiveProgramClient, String)) = New List(Of Tuple(Of LiveProgramClient, String))
+        Private ReadOnly LiveProgramClientAndRoomLabels As List(Of (client As LiveProgramClient, label As String)) = New List(Of (client As LiveProgramClient, label As String))
 
         Private _ConnectCommand As ICommand
         Public ReadOnly Property ConnectCommand() As ICommand
@@ -890,7 +890,7 @@ Namespace ViewModel
                                 AddHandler client.CommentReceived, AddressOf LiveProgramClient_CommentReceived
                                 AddHandler client.ConnectedChanged, AddressOf LiveProgramClient_ConnectionStatusChanged
                                 client.ConnectAsync(server)
-                                Me.LiveProgramClientAndRoomLabels.Add(Tuple.Create(client, server.RoomLabel))
+                                Me.LiveProgramClientAndRoomLabels.Add((client, server.RoomLabel))
                             Next
                         End If
                         Connecting = False
@@ -993,7 +993,7 @@ Namespace ViewModel
 
             If LiveProgramClientAndRoomLabels.Count > 0 Then
                 For Each clientAndLabel In LiveProgramClientAndRoomLabels
-                    Dim client = clientAndLabel.Item1
+                    Dim client = clientAndLabel.client
                     RemoveHandler client.CommentReceived, AddressOf LiveProgramClient_CommentReceived
                     RemoveHandler client.ConnectedChanged, AddressOf LiveProgramClient_ConnectionStatusChanged
                     client.Close()
@@ -1179,7 +1179,7 @@ Namespace ViewModel
 
             If client.Connected Then
                 Dim prefix = "接続しました: "
-                Dim label = LiveProgramClientAndRoomLabels.Find(Function(clientAndLabel) clientAndLabel.Item1 Is client).Item2
+                Dim label = LiveProgramClientAndRoomLabels.Find(Function(clientAndLabel) clientAndLabel.client Is client).label
                 If Me.StatusMessage IsNot Nothing AndAlso Me.StatusMessage.StartsWith(prefix) Then
                     Me.StatusMessage &= ", " & label
                 Else

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -884,15 +884,15 @@ Namespace ViewModel
                     Sub(e)
                         If e.Exception IsNot Nothing Then
                             Me.StatusMessage = "エラー: " & e.Exception.InnerException.Message
-                            Exit Sub
+                        Else
+                            For Each server In e.Result
+                                Dim client = New LiveProgramClient()
+                                AddHandler client.CommentReceived, AddressOf LiveProgramClient_CommentReceived
+                                AddHandler client.ConnectedChanged, AddressOf LiveProgramClient_ConnectionStatusChanged
+                                client.ConnectAsync(server)
+                                Me.LiveProgramClientAndRoomLabels.Add(Tuple.Create(client, server.RoomLabel))
+                            Next
                         End If
-                        For Each server In e.Result
-                            Dim client = New LiveProgramClient()
-                            AddHandler client.CommentReceived, AddressOf LiveProgramClient_CommentReceived
-                            AddHandler client.ConnectedChanged, AddressOf LiveProgramClient_ConnectionStatusChanged
-                            client.ConnectAsync(server)
-                            Me.LiveProgramClientAndRoomLabels.Add(Tuple.Create(client, server.RoomLabel))
-                        Next
                         Connecting = False
                     End Sub)
 

--- a/NamaTyping/packages.config
+++ b/NamaTyping/packages.config
@@ -31,6 +31,7 @@
   <package id="System.Threading" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
+  <package id="System.ValueTuple" version="4.3.1" targetFramework="net452" />
   <package id="System.Xml.ReaderWriter" version="4.3.0" targetFramework="net452" />
   <package id="System.Xml.XDocument" version="4.3.0" targetFramework="net452" />
   <package id="Ude.NetStandard" version="1.0.1" targetFramework="net452" />


### PR DESCRIPTION
- 行頭にタイムタグではない `[` がある歌詞ファイル (*.lrc) を読み込むとクラッシュするバグを修正
- 運営NGワードについて「歌詞の一致部分に `/` を挿入」が有効の場合、その部分の歌詞の置換 (読み仮名での採点) が行われなくなるバグを修正
	+ (例) `息を殺して` という歌詞に対して、ニコ生タイピング用置換ファイル (*.repl.txt) で `息,いき` と `殺し,ころし` が設定されていた場合
		* 前のバージョンでの置換後歌詞は `いきを殺　して`
		* 現在のバージョンでの置換後歌詞は `いきをころして`
- ニコ生タイピング用置換ファイル (*.repl.txt) の再読み込みについて、一つ前に読み込んだ置換ファイルが適用されるバグを修正
- ニコ生タイピング用置換ファイル (*.repl.txt) 生成時、出力ファイル名が決定できなかった場合のエラーメッセージを、 `ファイル「○○○.repl.txt」がすでに存在します。` から  `ファイル「○○○ (100).repl.txt」がすでに存在します。` のようなものに変更
- 再生スピードの変更に未対応のファイル形式で、 `Windows Media Playerで再生できないファイルです` のような間違ったエラーメッセージが表示されていたバグを修正
- その他、内部的な改善