### PR TITLE
タイムタグに関する不具合などを改善

### DIFF
--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -335,7 +335,7 @@ Namespace Model
             End If
 
             For i = 0 To rawLines.Count - 2
-                If Not rawLines(i).EndsWith("]") Then
+                If Not Regex.IsMatch(rawLines(i), "\[\d{2}:\d{2}:\d{2}\]$") Then
                     rawLines(i) &= rawLines(i + 1).Substring(0, "[xx:xx:xx]".Length)
                 End If
             Next

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -610,7 +610,7 @@ Namespace ViewModel
 
                 Dim binding = New Binding("LyricFontSize") With {.Source = Me}
                 wtb.SetBinding(WipeTextBlock.FontSizeProperty, binding)
-                If _lyrics.WipeEnabled Then
+                If _lyrics.WipeEnabled AndAlso _lyrics.Lines(_lyricsIndex).Text <> "" Then
                     wtb.TextWithTimeTag = _lyrics.Lines(_lyricsIndex).TextWithTimeTag
                 Else
                     wtb.WipeEnabled = False

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -798,8 +798,11 @@ Namespace ViewModel
                 Dim l = New Lyrics
 
                 Dim errorMessage As String = Nothing
-                If Not l.TryLoad(dialog.FileName, errorMessage) Then
+                Dim result = l.TryLoad(dialog.FileName, errorMessage)
+                If errorMessage IsNot Nothing Then
                     StatusMessage = errorMessage
+                End If
+                If Not result Then
                     Exit Sub
                 End If
 

--- a/NamaTyping/WipeTextBlock.xaml.vb
+++ b/NamaTyping/WipeTextBlock.xaml.vb
@@ -11,6 +11,11 @@ Public Class WipeTextBlock
     Private WithEvents MyStoryboard As Storyboard
     Private _wipeDurations As List(Of TimeSpan)
 
+    ''' <summary>
+    ''' ワイプ表示を一旦停止する文字インデックスと停止時間。
+    ''' </summary>
+    Private _wipePauseDurations As Dictionary(Of Integer, TimeSpan) = New Dictionary(Of Integer, TimeSpan)
+
     Private _wipEnabled As Boolean = True
     Public Property WipeEnabled As Boolean
         Get
@@ -118,12 +123,16 @@ Public Class WipeTextBlock
 
     End Sub
 
-    Private Sub MyStoryboard_Completed(sender As Object, e As EventArgs) Handles MyStoryboard.Completed
+    Private Async Sub MyStoryboard_Completed(sender As Object, e As EventArgs) Handles MyStoryboard.Completed
 
         Do
             WipedTextEffect.PositionCount += 1
 
             If WipeAnimationTextEffect.PositionStart < Text.Length - 1 Then
+                If _wipePauseDurations.ContainsKey(WipeAnimationTextEffect.PositionStart + 1) Then
+                    Await Threading.Tasks.Task.Delay(_wipePauseDurations(WipeAnimationTextEffect.PositionStart + 1))
+                End If
+
                 WipeAnimationTextEffect.PositionStart += 1
 
                 If _wipeDurations(WipeAnimationTextEffect.PositionStart).TotalMilliseconds > 0 Then
@@ -158,7 +167,13 @@ Public Class WipeTextBlock
 
             If i > 0 Then
 
-                durations.AddRange(GetDurations(ts.Subtract(previousTimeSpan), GetTextWidths(previousLyric)))
+                Dim duration = ts.Subtract(previousTimeSpan)
+                If previousLyric = "" Then
+                    ' 連続したタイムタグなら
+                    _wipePauseDurations.Add(durations.Count, duration)
+                Else
+                    durations.AddRange(GetDurations(duration, GetTextWidths(previousLyric)))
+                End If
 
             End If
 

--- a/NamaTyping/WipeTextBlock.xaml.vb
+++ b/NamaTyping/WipeTextBlock.xaml.vb
@@ -158,11 +158,7 @@ Public Class WipeTextBlock
 
             If i > 0 Then
 
-                If ts.Subtract(previousTimeSpan) > TimeSpan.FromSeconds(0) Then
-                    durations.AddRange(GetDurations(ts.Subtract(previousTimeSpan), GetTextWidths(previousLyric)))
-                Else
-                    ' TODO invalid tag
-                End If
+                durations.AddRange(GetDurations(ts.Subtract(previousTimeSpan), GetTextWidths(previousLyric)))
 
             End If
 


### PR DESCRIPTION
### 逆転したタイムタグに対処
`[00:05:00]あ[00:05:10]い[00:05:20]う[00:05:30]え[00:05:25]お[00:05:40]`

上のような行があれば、ステータスバーに警告を表示し、`[00:05:25]` を無視してワイプ表示 (再生時間5.3秒〜5.4秒で `えお` をワイプ表示) します。

バージョン2.3.0では、該当行でクラッシュしていました。

### 最終行の行末にタイムタグが無い場合にクラッシュしていたバグを修正

バージョン2.3.0で発生。

### 同じタイムタグに対応
`[00:05:00]あ[00:05:10]いうえ[00:05:10]お[00:05:20]`

上のような行の場合、再生時間5.0〜5.1秒は `あ` をワイプ表示し、5.1秒の時点で `あいうえ` までワイプ表示せずに色を変え、5.1〜5.2秒で `お` をワイプ表示します。

バージョン2.3.0では、該当行でクラッシュしていました。

### 連続したタイムタグに対応
`[00:05:00]あ[00:05:10]い[00:05:20]う[00:05:30][00:07:00]え[00:07:10]お[00:07:20]`

上のような行の場合、再生時間5.0〜5.3秒は `あいう` をワイプ表示し、5.3秒〜7.0秒はワイプ表示を停止し、7.0〜7.2秒で `えお` をワイプ表示します。

つまり `[00:05:00]あ[00:05:10]い[00:05:20]う[00:05:30]　[00:07:00]え[00:07:10]お[00:07:20]` と似たような表示です。