### PR TITLE
再生ボタンを押したとき、最新の100行を残してログを削除 (ウィンドウ上部の採点メッセージなどが表示される場所)

### DIFF
--- a/NamaTyping/My Project/Settings.Designer.vb
+++ b/NamaTyping/My Project/Settings.Designer.vb
@@ -11,20 +11,15 @@
 Option Strict On
 Option Explicit On
 
-Imports System.CodeDom.Compiler
-Imports System.ComponentModel
-Imports System.ComponentModel.Design
-Imports System.Configuration
-Imports System.Runtime.CompilerServices
 
 
-<CompilerGenerated(),  _
- GeneratedCode("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0"),  _
- EditorBrowsable(EditorBrowsableState.Advanced)>  _
+<Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute(),  _
+ Global.System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "15.1.0.0"),  _
+ Global.System.ComponentModel.EditorBrowsableAttribute(Global.System.ComponentModel.EditorBrowsableState.Advanced)>  _
 Partial Friend NotInheritable Class MySettings
-    Inherits ApplicationSettingsBase
+    Inherits Global.System.Configuration.ApplicationSettingsBase
     
-    Private Shared defaultInstance As MySettings = CType(Synchronized(New MySettings()),MySettings)
+    Private Shared defaultInstance As MySettings = CType(Global.System.Configuration.ApplicationSettingsBase.Synchronized(New MySettings()),MySettings)
     
 #Region "My.Settings 自動保存機能"
 #If _MyType = "WindowsForms" Then
@@ -61,11 +56,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''設定が保存されたときのアセンブリバージョン。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("設定が保存されたときのアセンブリバージョン。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue(""),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("設定が保存されたときのアセンブリバージョン。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute(""),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property Version() As String
         Get
             Return CType(Me("Version"),String)
@@ -78,11 +73,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''最前面に表示。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("最前面に表示。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("False"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("最前面に表示。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("False"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property Topmost() As Boolean
         Get
             Return CType(Me("Topmost"),Boolean)
@@ -95,11 +90,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''ユーザー名の表示。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("ユーザー名の表示。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("False"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("ユーザー名の表示。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("False"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property ShowNameEntryMessages() As Boolean
         Get
             Return CType(Me("ShowNameEntryMessages"),Boolean)
@@ -112,11 +107,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''採点メッセージの表示。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("採点メッセージの表示。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("False"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("採点メッセージの表示。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("False"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property ShowPointMessages() As Boolean
         Get
             Return CType(Me("ShowPointMessages"),Boolean)
@@ -129,11 +124,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''コメントの表示。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("コメントの表示。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("True"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("コメントの表示。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("True"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property ShowFilteredMessages() As Boolean
         Get
             Return CType(Me("ShowFilteredMessages"),Boolean)
@@ -146,11 +141,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''表示するコメントの接頭辞。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("表示するコメントの接頭辞。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("■"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("表示するコメントの接頭辞。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("■"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property DisplayCommentPattern() As String
         Get
             Return CType(Me("DisplayCommentPattern"),String)
@@ -163,11 +158,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''色付きユーザーID (コンマ区切り)。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("色付きユーザーID (コンマ区切り)。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue(""),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("色付きユーザーID (コンマ区切り)。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute(""),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property HighlightUsers() As String
         Get
             Return CType(Me("HighlightUsers"),String)
@@ -180,11 +175,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''ログのフォントサイズ (10〜34)。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("ログのフォントサイズ (10〜34)。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("16"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("ログのフォントサイズ (10〜34)。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("16"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property MessageFontSize() As Double
         Get
             Return CType(Me("MessageFontSize"),Double)
@@ -197,11 +192,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''歌詞のフォントサイズ (10〜34)。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("歌詞のフォントサイズ (10〜34)。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("20"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("歌詞のフォントサイズ (10〜34)。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("20"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property LyricFontSize() As Double
         Get
             Return CType(Me("LyricFontSize"),Double)
@@ -214,11 +209,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''ランキングのフォントサイズ (10〜34)。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("ランキングのフォントサイズ (10〜34)。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("20"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("ランキングのフォントサイズ (10〜34)。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("20"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property RankingFontSize() As Double
         Get
             Return CType(Me("RankingFontSize"),Double)
@@ -231,11 +226,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''歌詞・ランキング背景の不透明度。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("歌詞・ランキング背景の不透明度。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("0.6"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("歌詞・ランキング背景の不透明度。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("0.6"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property BottomGridOpacity() As Double
         Get
             Return CType(Me("BottomGridOpacity"),Double)
@@ -248,11 +243,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''表示する歌詞の行数 (1〜10)。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("表示する歌詞の行数 (1〜10)。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("3"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("表示する歌詞の行数 (1〜10)。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("3"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property RecentLyricLineCount() As Integer
         Get
             Return CType(Me("RecentLyricLineCount"),Integer)
@@ -265,11 +260,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''音量。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("音量。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("0.5"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("音量。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("0.5"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property Volume() As Double
         Get
             Return CType(Me("Volume"),Double)
@@ -282,11 +277,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''ウィンドウサイズなどのパターン (0〜3)。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("ウィンドウサイズなどのパターン (0〜3)。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("2"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("ウィンドウサイズなどのパターン (0〜3)。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("2"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property WindowSizePattern() As Integer
         Get
             Return CType(Me("WindowSizePattern"),Integer)
@@ -299,11 +294,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''運営NGワードについて、歌詞の一致部分を強調する。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("運営NGワードについて、歌詞の一致部分を強調する。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("True"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("運営NGワードについて、歌詞の一致部分を強調する。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("True"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property BlacklistCharactersHighlight() As Boolean
         Get
             Return CType(Me("BlacklistCharactersHighlight"),Boolean)
@@ -316,11 +311,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''運営NGワードについて、歌詞の一致部分に記号を挿入する。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("運営NGワードについて、歌詞の一致部分に記号を挿入する。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("True"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("運営NGワードについて、歌詞の一致部分に記号を挿入する。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("True"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property SplitBlacklistCharacters() As Boolean
         Get
             Return CType(Me("SplitBlacklistCharacters"),Boolean)
@@ -333,11 +328,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''すべての部屋からコメントを取得する。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("すべての部屋からコメントを取得する。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("False"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("すべての部屋からコメントを取得する。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("False"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property ConnectAllCommentServers() As Boolean
         Get
             Return CType(Me("ConnectAllCommentServers"),Boolean)
@@ -350,11 +345,11 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''経過時間と総時間を、歌詞表示領域の右上にも表示する
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("経過時間と総時間を、歌詞表示領域の右上にも表示する"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("True"),  _
-     SettingsManageability(SettingsManageability.Roaming)>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("経過時間と総時間を、歌詞表示領域の右上にも表示する"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("True"),  _
+     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
     Public Property ShowTimeOnLyricsGrid() As Boolean
         Get
             Return CType(Me("ShowTimeOnLyricsGrid"),Boolean)
@@ -367,10 +362,10 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''ウィンドウの横位置のキャッシュ。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("ウィンドウの横位置のキャッシュ。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("NaN")>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("ウィンドウの横位置のキャッシュ。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("NaN")>  _
     Public Property WindowLeft() As Double
         Get
             Return CType(Me("WindowLeft"),Double)
@@ -383,10 +378,10 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''ウィンドウの縦位置のキャッシュ。
     '''</summary>
-    <UserScopedSetting(),  _
-     SettingsDescription("ウィンドウの縦位置のキャッシュ。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("NaN")>  _
+    <Global.System.Configuration.UserScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("ウィンドウの縦位置のキャッシュ。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("NaN")>  _
     Public Property WindowTop() As Double
         Get
             Return CType(Me("WindowTop"),Double)
@@ -399,10 +394,10 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''運営NGワードを分断する文字。
     '''</summary>
-    <ApplicationScopedSetting(),  _
-     SettingsDescription("運営NGワードを分断する文字。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("/")>  _
+    <Global.System.Configuration.ApplicationScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("運営NGワードを分断する文字。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("/")>  _
     Public ReadOnly Property BlacklistCharactersSeparator() As String
         Get
             Return CType(Me("BlacklistCharactersSeparator"),String)
@@ -412,28 +407,41 @@ Partial Friend NotInheritable Class MySettings
     '''<summary>
     '''NGワード置換ファイルを手動でダウンロードするURL。
     '''</summary>
-    <ApplicationScopedSetting(),  _
-     SettingsDescription("NGワード置換ファイルを手動でダウンロードするURL。"),  _
-     DebuggerNonUserCode(),  _
-     DefaultSettingValue("https://id.pokemori.jp/niconico-live-ncv")>  _
+    <Global.System.Configuration.ApplicationScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("NGワード置換ファイルを手動でダウンロードするURL。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("https://id.pokemori.jp/niconico-live-ncv")>  _
     Public ReadOnly Property SubstitutionListDownloadURL() As String
         Get
             Return CType(Me("SubstitutionListDownloadURL"),String)
+        End Get
+    End Property
+    
+    '''<summary>
+    '''表示しているログを切り詰める際に、残しておく件数。
+    '''</summary>
+    <Global.System.Configuration.ApplicationScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("表示しているログを切り詰める際に、残しておく件数。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("100")>  _
+    Public ReadOnly Property RecentMessagesCount() As Integer
+        Get
+            Return CType(Me("RecentMessagesCount"),Integer)
         End Get
     End Property
 End Class
 
 Namespace My
     
-    <HideModuleName(),  _
-     DebuggerNonUserCode(),  _
-     CompilerGenerated()>  _
+    <Global.Microsoft.VisualBasic.HideModuleNameAttribute(),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Runtime.CompilerServices.CompilerGeneratedAttribute()>  _
     Friend Module MySettingsProperty
         
-        <HelpKeyword("My.Settings")>  _
-        Friend ReadOnly Property Settings() As MySettings
+        <Global.System.ComponentModel.Design.HelpKeywordAttribute("My.Settings")>  _
+        Friend ReadOnly Property Settings() As Global.Pronama.NamaTyping.MySettings
             Get
-                Return MySettings.Default
+                Return Global.Pronama.NamaTyping.MySettings.Default
             End Get
         End Property
     End Module

--- a/NamaTyping/My Project/Settings.settings
+++ b/NamaTyping/My Project/Settings.settings
@@ -68,5 +68,8 @@
     <Setting Name="SubstitutionListDownloadURL" Description="NGワード置換ファイルを手動でダウンロードするURL。" Type="System.String" Scope="Application">
       <Value Profile="(Default)">https://id.pokemori.jp/niconico-live-ncv</Value>
     </Setting>
+    <Setting Name="RecentMessagesCount" Description="表示しているログを切り詰める際に、残しておく件数。" Type="System.Int32" Scope="Application">
+      <Value Profile="(Default)">100</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -714,6 +714,7 @@ Namespace ViewModel
             _lyricsIndex = 0
             _startDateTime = Now
 
+            TruncateOldMessages(My.Settings.RecentMessagesCount)
             RankedUsers.Clear()
 
 
@@ -1376,6 +1377,16 @@ Namespace ViewModel
                 OnPropertyChanged("ShowTimeOnLyricsGrid")
             End Set
         End Property
+
+        ''' <summary>
+        ''' 表示しているログを、指定件数だけ残して切り詰めます。
+        ''' </summary>
+        ''' <param name="count"></param>
+        Private Sub TruncateOldMessages(count As Integer)
+            For i = 1 To Messages.Count - count
+                Messages.RemoveAt(0)
+            Next
+        End Sub
 
     End Class
 End Namespace

--- a/NamaTyping/app.config
+++ b/NamaTyping/app.config
@@ -105,6 +105,9 @@
       <setting name="SubstitutionListDownloadURL" serializeAs="String">
         <value>https://id.pokemori.jp/niconico-live-ncv</value>
       </setting>
+      <setting name="RecentMessagesCount" serializeAs="String">
+        <value>100</value>
+      </setting>
     </Pronama.NamaTyping.MySettings>
     <NMeCab.Properties.Settings>
       <setting name="DicDir" serializeAs="String">


### PR DESCRIPTION
採点メッセージの表示などにより、ログがたまって動作が重くなる場合があったので、この機能を実装しました。