### PR TITLE
ニコ生タイピング用置換ファイル (*.repl.txt) 生成時、読み仮名の取得に失敗するとクラッシュするバグを修正

### DIFF
--- a/NamaTyping/ReplacementWordsGenerator.vb
+++ b/NamaTyping/ReplacementWordsGenerator.vb
@@ -111,7 +111,10 @@ Friend NotInheritable Class ReplacementWordsGenerator
         Dim node = Tagger.ParseToNode(lrycs)
         While node IsNot Nothing
             If node.CharType = CharacterCategory.Kanji OrElse node.CharType = CharacterCategory.Kanjinumeric Then
-                replacementWords.Add(node.Surface & "," & node.Feature.Split(","c)(YomiIndex).ToHiragana() & vbCrLf)
+                Dim feature = node.Feature.Split(","c)
+                If (feature.Length > YomiIndex) Then
+                    replacementWords.Add(node.Surface & "," & feature(YomiIndex).ToHiragana() & vbCrLf)
+                End If
             End If
             node = node.Next
         End While


### PR DESCRIPTION
ニコ生タイピング用置換ファイル `*.repl.txt` 生成機能は完全ではないので、適宜修正をお願いします。

### 置換後の歌詞を確認する方法
1. ニコ生タイピングで曲を開きます。  
   ![](https://user-images.githubusercontent.com/3625160/28994814-4e04e76e-7a12-11e7-9f0c-bc30ae8cd095.png)
2. ウィンドウ上部の `テスト ツールバーの表示` ボタンをクリックします。  
   ![](https://user-images.githubusercontent.com/3625160/28994817-4e0b7c32-7a12-11e7-83cd-d3366aece447.png)
3. ウィンドウ下部に表示されたテストツールバー左端の `置換後 歌詞表示` ボタンをクリックします。  
   ![](https://user-images.githubusercontent.com/3625160/28994815-4e08b7cc-7a12-11e7-8459-1611906454a1.png)
4. 開いたウィンドウに、採点の区切りごとに改行されて置換後の歌詞が表示されるので、間違っている部分があれば `*.repl.txt` を修正して上書き保存します。
5. ウィンドウ左上の `再読み込み` ボタンを押すと、修正が反映されるので、確認します。  
   ![](https://user-images.githubusercontent.com/3625160/28994816-4e08f660-7a12-11e7-814e-69efdb0ac124.png)



