### PR TITLE
読み仮名に関するバグなどを修正

### DIFF
--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -306,11 +306,17 @@ Namespace Model
                     Continue For
                 End If
 
-                values(0) = values(0).ToLyricsWords(False)
+                values(0) = values(0).Trim().ToLyricsWords(False)
+                If values(0) = "" Then
+                    ' 検索文字列が空白文字のみで構成されていれば
+                    ' 無効
+                    Continue For
+                End If
+
                 If Not ReplacementWords.ContainsKey(values(0)) Then
                     values(1) = values(1).ToLyricsWords(True)
                     If values(1) <> "" Then
-                        ReplacementWords.Add(values(0).Trim, values(1))
+                        ReplacementWords.Add(values(0), values(1))
                     End If
                 Else
                     ' MEMO: 風クスの同じ単語がある場合

--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -307,8 +307,8 @@ Namespace Model
                 End If
 
                 values(0) = values(0).Trim().ToLyricsWords(False)
-                If values(0) = "" Then
-                    ' 検索文字列が空白文字のみで構成されていれば
+                If values(0) = "" OrElse values(0).Contains(" ") Then
+                    ' 検索文字列が空白文字のみで構成されている、または記号類が含まれていれば
                     ' 無効
                     Continue For
                 End If

--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -306,8 +306,12 @@ Namespace Model
                     Continue For
                 End If
 
+                values(0) = values(0).ToLyricsWords(False)
                 If Not ReplacementWords.ContainsKey(values(0)) Then
-                    ReplacementWords.Add(values(0).Trim, values(1).Trim)
+                    values(1) = values(1).ToLyricsWords(True)
+                    If values(1) <> "" Then
+                        ReplacementWords.Add(values(0).Trim, values(1))
+                    End If
                 Else
                     ' MEMO: 風クスの同じ単語がある場合
                 End If

--- a/NamaTyping/Model/Lyrics.vb
+++ b/NamaTyping/Model/Lyrics.vb
@@ -291,11 +291,9 @@ Namespace Model
         Private Sub LoadReplacementWords(file As String, ByRef encoding As Encoding)
             ReplacementWords.Clear()
 
-            Dim readLines = ReadLinesWithoutBlankLines(ReadAllText(file, encoding))
+            Dim words = New Dictionary(Of String, String)
 
-            Dim sortedLines = From l In readLines Order By l.Length Descending
-
-            For Each l In sortedLines
+            For Each l In ReadLinesWithoutBlankLines(ReadAllText(file, encoding))
                 If Not l.Contains(",") Then
                     Continue For
                 End If
@@ -313,14 +311,18 @@ Namespace Model
                     Continue For
                 End If
 
-                If Not ReplacementWords.ContainsKey(values(0)) Then
+                If Not words.ContainsKey(values(0)) Then
                     values(1) = values(1).ToLyricsWords(True)
                     If values(1) <> "" Then
-                        ReplacementWords.Add(values(0), values(1))
+                        words.Add(values(0), values(1))
                     End If
                 Else
                     ' MEMO: 風クスの同じ単語がある場合
                 End If
+            Next
+
+            For Each values In From l In words Order By l.Key.Length Descending
+                ReplacementWords.Add(values)
             Next
 
         End Sub


### PR DESCRIPTION
- 読みに含まれる記号類が削除されていなかった問題を修正
- 英数字の読み仮名の置換が正常に行われていなかったバグを修正
	+ 特にアルファベットについて、歌詞ファイル (*.lrc) の中では小文字でも、ニコ生タイピング用置換ファイル (\*.repl.txt) では大文字で記述しないと無視されていました。
- ニコ生タイピング用置換ファイル (*.repl.txt) の `,` の前が空白文字のみだった場合、読み込み時にクラッシュしていたバグを修正
- 検索文字列 (置き換え前の文字列) が長いほど優先して置換するようにした
	+ 前のバージョンでは、ニコ生タイピング用置換ファイル (*.repl.txt) で長い行 (検索文字列+置換文字列) を優先していた