### PR TITLE
新配信のFlash版が廃止され不要になったため、「歌詞の下の余白を大きくする」設定を削除

### DIFF
--- a/NamaTyping/ConsoleWindow.xaml
+++ b/NamaTyping/ConsoleWindow.xaml
@@ -25,8 +25,6 @@
                 <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="{Binding BottomGridOpacity, StringFormat=0.00}" />
             </StackPanel>
 
-            <CheckBox Content="歌詞の下の余白を大きくする" IsChecked="{Binding MakeLyricsBottomMarginLarge}" Margin="0,0,0,10" />
-
             <CheckBox Content="再生時間を、歌詞表示領域にも表示する" IsChecked="{Binding ShowTimeOnLyricsGrid}" Margin="0,0,0,10" />
 
             <CheckBox Content="すべてから部屋のコメントを取得する" IsChecked="{Binding ConnectAllCommentServers}" />

--- a/NamaTyping/My Project/AssemblyInfo.vb
+++ b/NamaTyping/My Project/AssemblyInfo.vb
@@ -56,4 +56,4 @@ Imports System.Windows
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("2.5.0.0")>
-<Assembly: AssemblyFileVersion("2.8.0.0")>
+<Assembly: AssemblyFileVersion("2.7.1.0")>

--- a/NamaTyping/My Project/Settings.Designer.vb
+++ b/NamaTyping/My Project/Settings.Designer.vb
@@ -360,23 +360,6 @@ Partial Friend NotInheritable Class MySettings
     End Property
     
     '''<summary>
-    '''歌詞の下の余白を大きくする
-    '''</summary>
-    <Global.System.Configuration.UserScopedSettingAttribute(),  _
-     Global.System.Configuration.SettingsDescriptionAttribute("歌詞の下の余白を大きくする"),  _
-     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
-     Global.System.Configuration.DefaultSettingValueAttribute("False"),  _
-     Global.System.Configuration.SettingsManageabilityAttribute(Global.System.Configuration.SettingsManageability.Roaming)>  _
-    Public Property MakeLyricsBottomMarginLarge() As Boolean
-        Get
-            Return CType(Me("MakeLyricsBottomMarginLarge"),Boolean)
-        End Get
-        Set
-            Me("MakeLyricsBottomMarginLarge") = value
-        End Set
-    End Property
-    
-    '''<summary>
     '''ウィンドウの横位置のキャッシュ。
     '''</summary>
     <Global.System.Configuration.UserScopedSettingAttribute(),  _

--- a/NamaTyping/My Project/Settings.settings
+++ b/NamaTyping/My Project/Settings.settings
@@ -56,9 +56,6 @@
     <Setting Name="ShowTimeOnLyricsGrid" Description="経過時間と総時間を、歌詞表示領域の右上にも表示する" Roaming="true" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="MakeLyricsBottomMarginLarge" Description="歌詞の下の余白を大きくする" Roaming="true" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">False</Value>
-    </Setting>
     <Setting Name="WindowLeft" Description="ウィンドウの横位置のキャッシュ。" Type="System.Double" Scope="User">
       <Value Profile="(Default)">NaN</Value>
     </Setting>

--- a/NamaTyping/ScreenControl.xaml
+++ b/NamaTyping/ScreenControl.xaml
@@ -243,7 +243,7 @@
             </StackPanel>
 
             <!-- Lyrics -->
-            <Grid Name="LyricsGrid" Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch" Background="Transparent">
+            <Grid Name="LyricsGrid" Grid.Row="2" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
             	<i:Interaction.Triggers>
             		<ic:DataTrigger Binding="{Binding Playing}" Value="True">
             			<ic:GoToStateAction StateName="ShowLyrics"/>
@@ -255,15 +255,7 @@
                         <RowDefinition />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <ItemsControl ItemsSource="{Binding RecentLyrics}">
-                        <i:Interaction.Triggers>
-                            <ic:DataTrigger Binding="{Binding MakeLyricsBottomMarginLarge}" Value="True">
-                                <ic:ChangePropertyAction PropertyName="Margin" Value="0 0 0 36"/>
-                            </ic:DataTrigger>
-                            <ic:DataTrigger Binding="{Binding MakeLyricsBottomMarginLarge}" Value="False">
-                                <ic:ChangePropertyAction PropertyName="Margin"/>
-                            </ic:DataTrigger>
-                        </i:Interaction.Triggers>
+                    <ItemsControl ItemsSource="{Binding RecentLyrics}" x:Name="LyricItemsControl">
                         <ItemsControl.Template>
                             <ControlTemplate>
                                 <ScrollViewer VerticalScrollBarVisibility="Hidden" HorizontalScrollBarVisibility="Hidden">
@@ -303,7 +295,7 @@
                             <Style TargetType="{x:Type ToolBarPanel}">
                                 <Setter Property="Visibility" Value="Collapsed" />
                                 <Style.Triggers>
-                                    <DataTrigger  Binding="{Binding IsMouseOver, ElementName=LyricsGrid}" Value="True">
+                                    <DataTrigger  Binding="{Binding IsMouseOver, ElementName=LyricItemsControl}" Value="True">
                                         <Setter Property="Visibility" Value="Visible" />
                                     </DataTrigger>
                                     <Trigger Property="IsMouseOver" Value="True">

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -1381,16 +1381,6 @@ Namespace ViewModel
             End Set
         End Property
 
-        Public Property MakeLyricsBottomMarginLarge As Boolean
-            Get
-                Return My.Settings.MakeLyricsBottomMarginLarge
-            End Get
-            Set
-                My.Settings.MakeLyricsBottomMarginLarge = Value
-                OnPropertyChanged("MakeLyricsBottomMarginLarge")
-            End Set
-        End Property
-
         ''' <summary>
         ''' 表示しているログを、指定件数だけ残して切り詰めます。
         ''' </summary>

--- a/NamaTyping/app.config
+++ b/NamaTyping/app.config
@@ -89,9 +89,6 @@
       <setting name="ShowTimeOnLyricsGrid" serializeAs="String">
         <value>True</value>
       </setting>
-      <setting name="MakeLyricsBottomMarginLarge" serializeAs="String">
-        <value>False</value>
-      </setting>
       <setting name="WindowLeft" serializeAs="String">
         <value>NaN</value>
       </setting>


### PR DESCRIPTION
Reverts https://github.com/jz5/namatyping/pull/33 .