### PR TITLE
英語などの歌詞を打ち間違えたときの大幅減点 (いわゆる英語バグ) を軽減

### DIFF
--- a/NamaTyping/Application.xaml.vb
+++ b/NamaTyping/Application.xaml.vb
@@ -42,6 +42,8 @@ Class Application
         ViewModel.Dispatcher = ScreenWindow.Dispatcher
         ScreenWindow.Show()
 
+        ViewModel.ShowVersionInformation()
+
 
 #If DEBUG Then
         For i = 0 To 30

--- a/NamaTyping/ExtensionModule.vb
+++ b/NamaTyping/ExtensionModule.vb
@@ -68,7 +68,7 @@ Module ExtensionModule
     Public Function ToLyricsWords(text As String, removeSymbols As Boolean) As String
 
         Dim builder = New StringBuilder
-        For Each c In text
+        For Each c In Regex.Replace(text, ViewModel.MainViewModel.RemoveSymbols, "")
 
             If Char.IsLetterOrDigit(c) Then
 

--- a/NamaTyping/Model/User.vb
+++ b/NamaTyping/Model/User.vb
@@ -13,6 +13,17 @@
         End Set
     End Property
 
+    ''' <summary>
+    ''' ユーザー毎に固有の設定。
+    ''' </summary>
+    Public Property SettingFlags As String
+
+    ''' <summary>
+    ''' 設定名と<see cref="SettingFlags">に含まれるフラグの組。
+    ''' </summary>
+    Friend Shared ReadOnly Property SettingFlagList As New Dictionary(Of String, Char) From {
+    }
+
     Public Property Id As String
     Public Property Highlighted As Boolean
     Public Property Premium As Integer

--- a/NamaTyping/Model/User.vb
+++ b/NamaTyping/Model/User.vb
@@ -16,12 +16,13 @@
     ''' <summary>
     ''' ユーザー毎に固有の設定。
     ''' </summary>
-    Public Property SettingFlags As String
+    Public Property SettingFlags As String = ""
 
     ''' <summary>
     ''' 設定名と<see cref="SettingFlags">に含まれるフラグの組。
     ''' </summary>
     Friend Shared ReadOnly Property SettingFlagList As New Dictionary(Of String, Char) From {
+        {"improve english lyrics", "e"c}
     }
 
     Public Property Id As String

--- a/NamaTyping/My Project/AssemblyInfo.vb
+++ b/NamaTyping/My Project/AssemblyInfo.vb
@@ -56,4 +56,4 @@ Imports System.Windows
 ' <Assembly: AssemblyVersion("1.0.*")> 
 
 <Assembly: AssemblyVersion("2.5.1.0")>
-<Assembly: AssemblyFileVersion("2.7.1.0")>
+<Assembly: AssemblyFileVersion("3.0.0.0")>

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -355,7 +355,8 @@ Namespace ViewModel
 
         Private Sub AddMessage(no As Integer, message As String, kind As MessageKind)
 
-            If (kind = MessageKind.System AndAlso ShowPointMessages) OrElse
+            If kind = MessageKind.None OrElse
+                (kind = MessageKind.System AndAlso ShowPointMessages) OrElse
                 (kind = MessageKind.Filtered AndAlso ShowFilteredMessages) OrElse
                 (kind = MessageKind.Other AndAlso ShowOtherMessages) OrElse
                 (kind = MessageKind.NameEntry AndAlso ShowNameEntryMessages) Then

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -496,6 +496,7 @@ Namespace ViewModel
             ' TODO nest解消
 
             For Each t In texts
+                Dim scored = False
                 Do
                     For i = user.LyricsIndex To _lyricsIndex - 1
 
@@ -547,6 +548,8 @@ Namespace ViewModel
                                     Exit Do
                                 End If
 
+                                scored = True
+
                             Else
                                 Dim yomi = t.ToHiragana(_lyrics.ReplacementWords)
                                 If yomi.StartsWith(_lyrics.Lines(i).Yomi(j)) Then
@@ -592,6 +595,12 @@ Namespace ViewModel
                                     Else
                                         Exit Do
                                     End If
+
+                                    scored = True
+
+                                ElseIf scored And user.SettingFlags.Contains(NamaTyping.User.SettingFlagList("improve english lyrics")) Then
+                                    Exit Do
+
                                 End If
                             End If
 

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -17,6 +17,11 @@ Namespace ViewModel
     Public Class MainViewModel
         Inherits ViewModelBase
 
+        ''' <summary>
+        ''' 歌詞表示以外の処理では、始めから存在しない文字として扱う歌詞ファイル中の記号の正規表現文字列。
+        ''' </summary>
+        Friend Const RemoveSymbols As String = "['’.]+"
+
         Public Property Dispatcher As Dispatcher
 
         ''' <summary>

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -370,6 +370,30 @@ Namespace ViewModel
 
         End Sub
 
+        ''' <summary>
+        ''' 既定の設定で画面内に収まるログの行数。
+        ''' </summary>
+        Private Const DefaultShownLogLineCount = 7
+
+        ''' <summary>
+        ''' 最新<see cref="DefaultShownLogLineCount">件のログにバージョン情報が含まれていなければ追加します。
+        ''' </summary>
+        Public Sub ShowVersionInformation()
+            Dim version = FileVersionInfo.GetVersionInfo(
+                Reflection.Assembly.GetExecutingAssembly().Location
+            ).FileVersion
+
+            Dim versionInfo = $"{My.Application.Info.Title} {version}"
+
+            For Each message In Messages.Reverse().Take(DefaultShownLogLineCount)
+                If message = $"0: {versionInfo}" Then
+                    Exit Sub
+                End If
+            Next
+
+            AddMessage(0, versionInfo, MessageKind.None)
+        End Sub
+
         Private Member As New Dictionary(Of String, User)
 
         Public Sub InjectComment(comment As LiveCommentMessage)
@@ -1175,6 +1199,7 @@ Namespace ViewModel
                 OnRankingAdded()
             Else
                 RankingTimer.Stop()
+                ShowVersionInformation()
             End If
 
         End Sub


### PR DESCRIPTION
英語などの言語における特徴として、単語ごとに空白が生じます。そのため、タイプミスをした際、後の方の歌詞に一致してしまい、直感に反して大幅に減点される場合があります。

- **一部の記号 `’` `'` `.` について、空白を開けて打つことを禁止しました。**
	+ (例) `I’m` という歌詞に対して
		* 正: `Im`
		* 正: `I’m`
		* 誤: `I　m` (前のバージョンではこれも正解だった)
- _(既定で無効)_ 空白を挟まないと歌詞のSkipが行えないようにしました。
	+ `@参加者名[e]` のように名前を登録することで有効化できます。`@参加者名` のように名前を登録し直すと無効化できます。
	+ 例は以下をご覧ください。
- リスナー側から確認できるよう、ニコ生タイピングのバージョン情報がログに表示されるようになりました。

`あいうえお　かきくけこ　さ　あ` という歌詞に対して

|     | コメント                         | 通常の採点                             | `@参加者名[e]` と名前を登録したときの採点           |
|-----|----------------------------------|----------------------------------------|-----------------------------------------------------|
| 例1 | `あいうえおかきくけ　さ`         | Great　あいうえお<br>Great　さ         | Great　あいうえお<br>Great　さ                      |
| 例2 | `あいうえおかきくけさ`           | Great　あいうえお                      | Great　あいうえお                                   |
| 例3 | `あいうえおさ　かきくけこ　さ`   | Great　あいうえお<br>Skip<br>Great　さ | Great　あいうえお<br>Great　かきくけこ<br>Great　さ |
| 例4 | `あいうえおさかきくけこあ`       | Great　あいうえお<br>Skip<br>Great　さ | Great　あいうえお                                   |
| 例5 | `あいうえ　かきくけこ`           | Skip<br>Great　あ                      | Skip<br>Great　あ                                   |

- 例1 `かきくけ` を間違えているが、空白を挟んでいるため `さ` も採点される
- 例2 `かきくけ` を間違えているが、空白を挟んでいないため `さ` は採点されない
- 例3 `@参加者名[e]` で改善される例
- 例4 `@参加者名[e]` で点数が下がる例
- 例5 `@参加者名[e]` で改善されない例