### PR TITLE
ランキング表示にかかる時間の上限を20秒にした

### DIFF
--- a/NamaTyping/My Project/Settings.Designer.vb
+++ b/NamaTyping/My Project/Settings.Designer.vb
@@ -480,6 +480,19 @@ Partial Friend NotInheritable Class MySettings
             Return CType(Me("RecentMessagesCount"),Integer)
         End Get
     End Property
+    
+    '''<summary>
+    '''ランキング表示にかかる秒数の上限。
+    '''</summary>
+    <Global.System.Configuration.ApplicationScopedSettingAttribute(),  _
+     Global.System.Configuration.SettingsDescriptionAttribute("ランキング表示にかかる秒数の上限。"),  _
+     Global.System.Diagnostics.DebuggerNonUserCodeAttribute(),  _
+     Global.System.Configuration.DefaultSettingValueAttribute("20")>  _
+    Public ReadOnly Property DurationSecondsLimitDisplayingRanking() As Integer
+        Get
+            Return CType(Me("DurationSecondsLimitDisplayingRanking"),Integer)
+        End Get
+    End Property
 End Class
 
 Namespace My

--- a/NamaTyping/My Project/Settings.settings
+++ b/NamaTyping/My Project/Settings.settings
@@ -80,5 +80,8 @@
     <Setting Name="RecentMessagesCount" Description="表示しているログを切り詰める際に、残しておく件数。" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">100</Value>
     </Setting>
+    <Setting Name="DurationSecondsLimitDisplayingRanking" Description="ランキング表示にかかる秒数の上限。" Type="System.Int32" Scope="Application">
+      <Value Profile="(Default)">20</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -1103,8 +1103,16 @@ Namespace ViewModel
                 Next
             End If
 
+            ' 表示時間の調整
+            Dim spanSeconds = 1.0
+            Dim durationSenconds = orderedMember.Count * spanSeconds
+            If durationSenconds > My.Settings.DurationSecondsLimitDisplayingRanking Then
+                durationSenconds = My.Settings.DurationSecondsLimitDisplayingRanking
+                spanSeconds = durationSenconds / orderedMember.Count
+            End If
+
             If Player.HasAudio Then
-                Dim p = Player.NaturalDuration.TimeSpan.TotalSeconds - (orderedMember.Count + 1)
+                Dim p = Player.NaturalDuration.TimeSpan.TotalSeconds - (spanSeconds * orderedMember.Count + 1)
                 If p < 0 Then
                     p = 0
                 End If
@@ -1114,7 +1122,7 @@ Namespace ViewModel
                 Player.Play()
             End If
 
-            RankingTimer.Interval = New TimeSpan(0, 0, 1)
+            RankingTimer.Interval = TimeSpan.FromSeconds(spanSeconds)
             RankingTimer.Start()
 
             '#If DEBUG Then

--- a/NamaTyping/app.config
+++ b/NamaTyping/app.config
@@ -117,6 +117,9 @@
       <setting name="RecentMessagesCount" serializeAs="String">
         <value>100</value>
       </setting>
+      <setting name="DurationSecondsLimitDisplayingRanking" serializeAs="String">
+        <value>20</value>
+      </setting>
     </Pronama.NamaTyping.MySettings>
     <NMeCab.Properties.Settings>
       <setting name="DicDir" serializeAs="String">


### PR DESCRIPTION
前のバージョンまでは、コメントしたユーザー1人につき常に1秒で表示していたため、コメントしたユーザーが多い場合、全員の点数を表示し終えるまで非常に時間がかかっていました。20人を超える場合、コメントしたユーザーが多いほど、各ユーザーの点数表示時間が短くなるよう調整します。