### PR TITLE
配信への接続時にニコ生タイピングが落ちる不具合を修正

### DIFF
--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -943,6 +943,8 @@ Namespace ViewModel
                 StatusMessage = $"「{LiveProgramId}」は現在配信中ではありません。"
             Catch ex As Exception When ex.Message = "require_community_member"
                 StatusMessage = "ニコ生タイピングは、フォロワー限定 (コミュ限) の配信には接続できません。"
+            Catch ex As Exception When ex.Message = "status_7"
+                StatusMessage = $"「{LiveProgramId}」は見つかりません。"
             End Try
 
             _connecting = False

--- a/NamaTyping/ViewModel/MainViewModel.vb
+++ b/NamaTyping/ViewModel/MainViewModel.vb
@@ -939,7 +939,7 @@ Namespace ViewModel
                 AddHandler _liveProgramClient.ConnectedChanged, AddressOf LiveProgramClient_ConnectionStatusChanged
                 _liveProgramClient.ConnectAsync(server)
                 RecommnedDisablingCommentFilter()
-            Catch ex As Exception When ex.Message = "closed"
+            Catch ex As Exception When ex.Message = "comingsoon" OrElse ex.Message = "closed"
                 StatusMessage = $"「{LiveProgramId}」は現在配信中ではありません。"
             Catch ex As Exception When ex.Message = "require_community_member"
                 StatusMessage = "ニコ生タイピングは、フォロワー限定 (コミュ限) の配信には接続できません。"


### PR DESCRIPTION
- 配信開始前の生放送IDを指定したとき
- 存在しない生放送IDを指定したとき