### PR TITLE
[NamaTyping] System.IO.FileNotFoundException を回避

### DIFF
--- a/NamaTyping.NicoVideo/LiveProgramClient.Chunked.cs
+++ b/NamaTyping.NicoVideo/LiveProgramClient.Chunked.cs
@@ -35,24 +35,24 @@ public partial class LiveProgramClient
         _messageIds.Clear();
 
         var retriever = new Retriever();
-        //var entryParser = new MessageParser<ChunkedEntry>(() => new ChunkedEntry());
-        //var messageParser = new MessageParser<ChunkedMessage>(() => new ChunkedMessage());
+        var entryParser = new MessageParser<ChunkedEntry>(() => new ChunkedEntry());
+        var messageParser = new MessageParser<ChunkedMessage>(() => new ChunkedMessage());
 
         var at = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
         var uri = MessageServerMessage.Data.ViewUri;
 
-        //_ = Task.Run(async () =>
-        //{
-        //    try
-        //    {
-        //        await FetchForwardPlaylistMessagesAsync(retriever, entryParser, messageParser, uri, at);
-        //    }
-        //    catch (Exception e)
-        //    {
-        //        Console.WriteLine(e);
-        //        throw;
-        //    }
-        //});
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await FetchForwardPlaylistMessagesAsync(retriever, entryParser, messageParser, uri, at);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e);
+                throw;
+            }
+        });
 
 
         /*

--- a/NamaTyping/NamaTyping.vbproj
+++ b/NamaTyping/NamaTyping.vbproj
@@ -94,6 +94,9 @@
     <Reference Include="LibNMeCab, Version=0.0.6.4, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NMeCab.0.06.4\lib\LibNMeCab.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.Bcl.AsyncInterfaces, Version=7.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Bcl.AsyncInterfaces.7.0.0\lib\netstandard2.0\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Xaml.Behaviors, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Xaml.Behaviors.Wpf.1.1.19\lib\net45\Microsoft.Xaml.Behaviors.dll</HintPath>
     </Reference>
@@ -122,7 +125,7 @@
       <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.3\lib\net461\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
@@ -130,6 +133,9 @@
     <Reference Include="System.Security.Cryptography.Primitives" />
     <Reference Include="System.Security.Cryptography.X509Certificates" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.2.0.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Threading.Tasks.Extensions.4.5.4\lib\net461\System.Threading.Tasks.Extensions.dll</HintPath>
+    </Reference>
     <Reference Include="System.ValueTuple" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xaml" />

--- a/NamaTyping/NamaTyping.vbproj
+++ b/NamaTyping/NamaTyping.vbproj
@@ -88,6 +88,9 @@
     <ApplicationManifest>My Project\app.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Google.Protobuf, Version=3.27.3.0, Culture=neutral, PublicKeyToken=a7d26565bac4d604, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Protobuf.3.27.3\lib\net45\Google.Protobuf.dll</HintPath>
+    </Reference>
     <Reference Include="LibNMeCab, Version=0.0.6.4, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\NMeCab.0.06.4\lib\LibNMeCab.dll</HintPath>
     </Reference>
@@ -98,6 +101,9 @@
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework.Aero" />
     <Reference Include="PresentationFramework.Royale" />
+    <Reference Include="System.Buffers, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Buffers.4.4.0\lib\netstandard2.0\System.Buffers.dll</HintPath>
+    </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
@@ -107,8 +113,17 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Memory, Version=4.0.1.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Memory.4.5.3\lib\netstandard2.0\System.Memory.dll</HintPath>
+    </Reference>
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Numerics" />
+    <Reference Include="System.Numerics.Vectors, Version=4.1.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Numerics.Vectors.4.4.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.2\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
+    </Reference>
     <Reference Include="System.Runtime.InteropServices.RuntimeInformation" />
     <Reference Include="System.Security.Cryptography.Algorithms" />
     <Reference Include="System.Security.Cryptography.Encoding" />

--- a/NamaTyping/packages.config
+++ b/NamaTyping/packages.config
@@ -1,10 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Google.Protobuf" version="3.27.3" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="7.0.4" targetFramework="net461" />
   <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.19" targetFramework="net461" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net461" />
   <package id="Newtonsoft.Json" version="13.0.3" targetFramework="net461" />
   <package id="NMeCab" version="0.06.4" targetFramework="net452" />
+  <package id="System.Buffers" version="4.4.0" targetFramework="net461" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />
   <package id="System.Collections.Concurrent" version="4.3.0" targetFramework="net452" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net452" />
@@ -15,14 +17,17 @@
   <package id="System.IO.Compression" version="4.3.0" targetFramework="net461" />
   <package id="System.Linq" version="4.3.0" targetFramework="net452" />
   <package id="System.Linq.Expressions" version="4.3.0" targetFramework="net452" />
+  <package id="System.Memory" version="4.5.3" targetFramework="net461" />
   <package id="System.Net.Http" version="4.3.4" targetFramework="net461" />
   <package id="System.Net.Primitives" version="4.3.1" targetFramework="net461" />
+  <package id="System.Numerics.Vectors" version="4.4.0" targetFramework="net461" />
   <package id="System.ObjectModel" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Extensions" version="4.3.0" targetFramework="net452" />
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net461" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />

--- a/NamaTyping/packages.config
+++ b/NamaTyping/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Google.Protobuf" version="3.27.3" targetFramework="net461" />
+  <package id="Microsoft.Bcl.AsyncInterfaces" version="7.0.0" targetFramework="net461" />
   <package id="Microsoft.NETCore.Platforms" version="7.0.4" targetFramework="net461" />
   <package id="Microsoft.Xaml.Behaviors.Wpf" version="1.1.19" targetFramework="net461" />
   <package id="NETStandard.Library" version="2.0.3" targetFramework="net461" />
@@ -27,7 +28,7 @@
   <package id="System.Reflection.Primitives" version="4.3.0" targetFramework="net452" />
   <package id="System.Resources.ResourceManager" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime" version="4.3.1" targetFramework="net461" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.2" targetFramework="net461" />
+  <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net461" />
   <package id="System.Runtime.Extensions" version="4.3.1" targetFramework="net461" />
   <package id="System.Runtime.InteropServices" version="4.3.0" targetFramework="net452" />
   <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.3.0" targetFramework="net452" />
@@ -41,6 +42,7 @@
   <package id="System.Text.RegularExpressions" version="4.3.1" targetFramework="net461" />
   <package id="System.Threading" version="4.3.0" targetFramework="net452" />
   <package id="System.Threading.Tasks" version="4.3.0" targetFramework="net452" />
+  <package id="System.Threading.Tasks.Extensions" version="4.5.4" targetFramework="net461" />
   <package id="System.Threading.Timer" version="4.3.0" targetFramework="net452" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
   <package id="System.Xml.ReaderWriter" version="4.3.1" targetFramework="net461" />


### PR DESCRIPTION
少なくとも `ConnectMessageServer` 内に `var retriever = new Retriever();` があるだけでは例外が出なくなった