### PR TITLE
[NamaTyping.NicoVideo] 運営コメントを常に放送者コメントとみなすように

### DIFF
--- a/NamaTyping.NicoVideo/Comments/LiveCommentMessage.cs
+++ b/NamaTyping.NicoVideo/Comments/LiveCommentMessage.cs
@@ -49,7 +49,7 @@ public class LiveCommentMessage
                     Premium = null,
                     Content = chunkedMessage.State.Marquee?.Display?.OperatorComment?.Content,
                     DateTime = chunkedMessage.Meta.At.ToDateTimeOffset().DateTime,
-                    Source = ChatSource.Operator
+                    Source = ChatSource.Operator | ChatSource.Broadcaster
                 };
             case ChunkedMessage.PayloadOneofCase.State
                 when chunkedMessage.State.ProgramStatus?.State == ProgramStatus.Types.State.Ended:


### PR DESCRIPTION
現状マーキーエリアに表示されるのは放送者コメントのみであり、マーキーエリアの運営コメントを常に放送者コメントとみなしても良さそうである。